### PR TITLE
Update tree/pass model

### DIFF
--- a/src/NanopassSharp/Extensions.cs
+++ b/src/NanopassSharp/Extensions.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -51,4 +53,55 @@ public static class Extensions
         var result = await task;
         return await f(result);
     }
+
+    public static bool DictionaryEquals<TKey, TValue>(this IDictionary<TKey, TValue> source, IDictionary<TKey, TValue> other) =>
+        source.DictionaryEquals(other, EqualityComparer<TValue>.Default);
+    public static bool DictionaryEquals<TKey, TValue>(this IDictionary<TKey, TValue> source, IDictionary<TKey, TValue> other, IEqualityComparer<TValue> valueComparer) =>
+        DictionaryEquals(new ReadOnlyDictionaryAdapter<TKey, TValue>(source), new ReadOnlyDictionaryAdapter<TKey, TValue>(other), valueComparer);
+    public static bool DictionaryEquals<TKey, TValue>(this IDictionary<TKey, TValue> source, IReadOnlyDictionary<TKey, TValue> other) =>
+        source.DictionaryEquals(other, EqualityComparer<TValue>.Default);
+    public static bool DictionaryEquals<TKey, TValue>(this IDictionary<TKey, TValue> source, IReadOnlyDictionary<TKey, TValue> other, IEqualityComparer<TValue> valueComparer) =>
+        DictionaryEquals(new ReadOnlyDictionaryAdapter<TKey, TValue>(source), other, valueComparer);
+    public static bool DictionaryEquals<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> source, IDictionary<TKey, TValue> other) =>
+        source.DictionaryEquals(other, EqualityComparer<TValue>.Default);
+    public static bool DictionaryEquals<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> source, IDictionary<TKey, TValue> other, IEqualityComparer<TValue> valueComparer) =>
+        DictionaryEquals(source, new ReadOnlyDictionaryAdapter<TKey, TValue>(other), valueComparer);
+    public static bool DictionaryEquals<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> source, IReadOnlyDictionary<TKey, TValue> other) =>
+        source.DictionaryEquals(other, EqualityComparer<TValue>.Default);
+    public static bool DictionaryEquals<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> source, IReadOnlyDictionary<TKey, TValue> other, IEqualityComparer<TValue> valueComparer)
+    {
+        if (source.Count != other.Count) return false;
+
+        foreach (var (key, sourceValue) in source)
+        {
+            if (!other.ContainsKey(key)) return false;
+
+            var otherValue = other[key];
+            if (!valueComparer.Equals(sourceValue, otherValue)) return false;
+        }
+
+        return true;
+    }
+    private sealed class ReadOnlyDictionaryAdapter<TKey, TValue> : IReadOnlyDictionary<TKey, TValue>
+    {
+        private readonly IDictionary<TKey, TValue> dictionary;
+
+        public TValue this[TKey key] => dictionary[key];
+        public IEnumerable<TKey> Keys => dictionary.Keys;
+        public IEnumerable<TValue> Values => dictionary.Values;
+        public int Count => dictionary.Count;
+
+        public ReadOnlyDictionaryAdapter(IDictionary<TKey, TValue> dictionary)
+        {
+            this.dictionary = dictionary;
+        }
+
+        public bool ContainsKey(TKey key) => dictionary.ContainsKey(key);
+        public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator() => dictionary.GetEnumerator();
+        public bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue value) => dictionary.TryGetValue(key, out value);
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    public static bool SetEquals<T>(this ISet<T> source, ISet<T> other) =>
+        source.Count == other.Count && source.Overlaps(other);
 }

--- a/src/NanopassSharp/Extensions.cs
+++ b/src/NanopassSharp/Extensions.cs
@@ -7,7 +7,6 @@ namespace NanopassSharp;
 
 public static class Extensions
 {
-
     public static IEnumerable<(T first, T second)> WithNext<T>(this IEnumerable<T> source)
     {
         T? prev = default;
@@ -52,5 +51,4 @@ public static class Extensions
         var result = await task;
         return await f(result);
     }
-
 }

--- a/src/NanopassSharp/Functional/Result.cs
+++ b/src/NanopassSharp/Functional/Result.cs
@@ -14,7 +14,6 @@ namespace NanopassSharp.Functional;
 /// <typeparam name="T">The type of the success value.</typeparam>
 public readonly struct Result<T> : IEquatable<Result<T>>, IEquatable<T>
 {
-
     /// <summary>
     /// The result value.
     /// </summary>
@@ -203,12 +202,10 @@ public readonly struct Result<T> : IEquatable<Result<T>>, IEquatable<T>
         result.Equals(value);
     public static bool operator !=(Result<T> result, T value) =>
         !result.Equals(value);
-
 }
 
 public static class Result
 {
-
     /// <summary>
     /// Creates a <see cref="Result{T}"/> with a successful state.
     /// </summary>
@@ -249,5 +246,4 @@ public static class Result
         value is not null
             ? new(value.Value)
             : new(error ?? $"{callerExpression} was null");
-
 }

--- a/src/NanopassSharp/Functional/ResultExtensions.cs
+++ b/src/NanopassSharp/Functional/ResultExtensions.cs
@@ -3,7 +3,6 @@
 namespace NanopassSharp.Functional;
 public static class ResultExtensions
 {
-
     /// <summary>
     /// Returns the inner value as either itself or the type's default value.
     /// </summary>
@@ -40,5 +39,4 @@ public static class ResultExtensions
                 new Result<U>(f(x))
             )
         );
-
 }

--- a/src/NanopassSharp/Functional/TaskResultExtensions.cs
+++ b/src/NanopassSharp/Functional/TaskResultExtensions.cs
@@ -5,7 +5,6 @@ namespace NanopassSharp.Functional;
 
 public static class TaskResultExtensions
 {
-
     public static async Task<TResult> SwitchResultAsync<T, TResult>(this Task<Result<T>> source, Func<T, Task<TResult>> ifSuccess, Func<string, Task<TResult>> ifFailure) =>
         await (await source).SwitchAsync(ifSuccess, ifFailure);
     public static async Task<TResult> SwitchResultAsync<T, TResult>(this Task<Result<T>> source, Func<T, TResult> ifSuccess, Func<string, TResult> ifFailure) =>
@@ -89,5 +88,4 @@ public static class TaskResultExtensions
     public static async Task<Result<T>> NotNullResultAsync<T>(this Task<Result<T?>> result, string? error = null)
     where T : struct =>
         (await result).Bind(v => v is not null ? new Result<T>(v.Value) : error ?? "Inner result value was null");
-
 }

--- a/src/NanopassSharp/ITransformation.cs
+++ b/src/NanopassSharp/ITransformation.cs
@@ -15,7 +15,7 @@ public interface ITransformation
     /// </summary>
     /// <param name="tree">The node tree to apply the transformation onto.</param>
     /// <returns>A new node tree with the applied transformation.</returns>
-    TypeNodeTree Apply(TypeNodeTree tree);
+    AstNodeHierarchy Apply(AstNodeHierarchy tree);
 
 }
 
@@ -33,6 +33,6 @@ public interface ITransformationPattern
     /// Returns whether a node matches the pattern.
     /// </summary>
     /// <param name="node">The node to check.</param>
-    bool IsMatch(TypeNode node);
+    bool IsMatch(AstNode node);
 
 }

--- a/src/NanopassSharp/ITransformation.cs
+++ b/src/NanopassSharp/ITransformation.cs
@@ -5,7 +5,6 @@
 /// </summary>
 public interface ITransformationInfo
 {
-
     /// <summary>
     /// The pattern the transformation is triggered by.
     /// </summary>
@@ -14,7 +13,6 @@ public interface ITransformationInfo
     /// The transformation to apply.
     /// </summary>
     ITransformation Transformation { get; }
-
 }
 
 /// <summary>
@@ -22,7 +20,6 @@ public interface ITransformationInfo
 /// </summary>
 public interface ITransformation
 {
-
     /// <summary>
     /// Applies the transformation to a node tree.
     /// </summary>
@@ -38,7 +35,6 @@ public interface ITransformation
     /// <param name="member">The member to apply the transformation to.</param>
     /// <returns>A new member with the applied transformation.</returns>
     AstNodeMember ApplyToMember(AstNodeHierarchy tree, AstNode node, AstNodeMember member);
-
 }
 
 /// <summary>
@@ -46,7 +42,6 @@ public interface ITransformation
 /// </summary>
 public interface ITransformationPattern
 {
-
     /// <summary>
     /// Whether the pattern is recursive.
     /// </summary>
@@ -63,5 +58,4 @@ public interface ITransformationPattern
     /// <param name="node">The node the member is a part of.</param>
     /// <param name="member">The node member to check.</param>
     bool IsMatch(AstNode node, AstNodeMember member);
-
 }

--- a/src/NanopassSharp/ITransformation.cs
+++ b/src/NanopassSharp/ITransformation.cs
@@ -1,9 +1,9 @@
 ﻿namespace NanopassSharp;
 
 /// <summary>
-/// A transformation on a node tree.
+/// Information about a transformation and pattern.
 /// </summary>
-public interface ITransformation
+public interface ITransformationInfo
 {
 
     /// <summary>
@@ -11,11 +11,33 @@ public interface ITransformation
     /// </summary>
     ITransformationPattern? Pattern { get; }
     /// <summary>
-    /// Applies the transformation onto a node tree.
+    /// The transformation to apply.
     /// </summary>
-    /// <param name="tree">The node tree to apply the transformation onto.</param>
-    /// <returns>A new node tree with the applied transformation.</returns>
-    AstNodeHierarchy Apply(AstNodeHierarchy tree);
+    ITransformation Transformation { get; }
+
+}
+
+/// <summary>
+/// A transformation on a node or node member.
+/// </summary>
+public interface ITransformation
+{
+
+    /// <summary>
+    /// Applies the transformation to a node tree.
+    /// </summary>
+    /// <param name="tree">The tree the node is a part of.</param>
+    /// <param name="node">The node to apply the transformation to.</param>
+    /// <returns>A new node with the applied transformation.</returns>
+    AstNode ApplyToNode(AstNodeHierarchy tree, AstNode node);
+    /// <summary>
+    /// Applies the transformation to a node member.
+    /// </summary>
+    /// <param name="tree">The tree the node of the member is a part of.</param>
+    /// <param name="node">The node the member is a part of.</param>
+    /// <param name="member">The member to apply the transformation to.</param>
+    /// <returns>A new member with the applied transformation.</returns>
+    AstNodeMember ApplyToMember(AstNodeHierarchy tree, AstNode node, AstNodeMember member);
 
 }
 
@@ -29,10 +51,17 @@ public interface ITransformationPattern
     /// Whether the pattern is recursive.
     /// </summary>
     bool IsRecursive { get; }
+
     /// <summary>
     /// Returns whether a node matches the pattern.
     /// </summary>
     /// <param name="node">The node to check.</param>
     bool IsMatch(AstNode node);
+    /// <summary>
+    /// Returns whether a member of a node matches the pattern.
+    /// </summary>
+    /// <param name="node">The node the member is a part of.</param>
+    /// <param name="member">The node member to check.</param>
+    bool IsMatch(AstNode node, AstNodeMember member);
 
 }

--- a/src/NanopassSharp/ITransformation.cs
+++ b/src/NanopassSharp/ITransformation.cs
@@ -1,0 +1,38 @@
+﻿namespace NanopassSharp;
+
+/// <summary>
+/// A transformation on a node tree.
+/// </summary>
+public interface ITransformation
+{
+
+    /// <summary>
+    /// The pattern the transformation is triggered by.
+    /// </summary>
+    ITransformationPattern? Pattern { get; }
+    /// <summary>
+    /// Applies the transformation onto a node tree.
+    /// </summary>
+    /// <param name="tree">The node tree to apply the transformation onto.</param>
+    /// <returns>A new node tree with the applied transformation.</returns>
+    TypeNodeTree Apply(TypeNodeTree tree);
+
+}
+
+/// <summary>
+/// A pattern for a transformation.
+/// </summary>
+public interface ITransformationPattern
+{
+
+    /// <summary>
+    /// Whether the pattern is recursive.
+    /// </summary>
+    bool IsRecursive { get; }
+    /// <summary>
+    /// Returns whether a node matches the pattern.
+    /// </summary>
+    /// <param name="node">The node to check.</param>
+    bool IsMatch(TypeNode node);
+
+}

--- a/src/NanopassSharp/ITransformation.cs
+++ b/src/NanopassSharp/ITransformation.cs
@@ -1,9 +1,9 @@
 ﻿namespace NanopassSharp;
 
 /// <summary>
-/// Information about a transformation and pattern.
+/// A description of a transformation and pattern.
 /// </summary>
-public interface ITransformationInfo
+public interface ITransformationDescription
 {
     /// <summary>
     /// The pattern the transformation is triggered by.

--- a/src/NanopassSharp/Models/PassModel.cs
+++ b/src/NanopassSharp/Models/PassModel.cs
@@ -5,28 +5,22 @@ namespace NanopassSharp.Models;
 
 public sealed class PassModel
 {
-
     public string Name { get; set; } = "";
     public ModificationPassModel? Mod { get; set; }
     public string? Type { get; set; }
-
 }
 
 public sealed class ModificationPassModel
 {
-
     public string? TypeName { get; set; }
     public List<ModificationModel> Add { get; set; } = new();
     public List<ModificationModel> Remove { get; set; } = new();
-
 }
 
 public sealed class ModificationModel
 {
-
     public string Target { get; set; } = "";
     public string? Parameter { get; set; }
     public string? Property { get; set; }
     public string? Type { get; set; }
-
 }

--- a/src/NanopassSharp/Pass.cs
+++ b/src/NanopassSharp/Pass.cs
@@ -23,20 +23,12 @@ public sealed record class CompilerPass
     /// </summary>
     public CompilerPass? Next { get; set; }
 
-    private Task<AstNodeHierarchy>? treeTask;
+    private AstNodeHierarchy? tree;
     /// <summary>
-    /// Gets the transformed tree of this pass.
+    /// The transformed tree of this pass.
     /// </summary>
-    public Task<AstNodeHierarchy> GetTreeAsync()
-    {
-        treeTask ??= GetTreeInternalAsync();
-        return treeTask;
-    }
-    private async Task<AstNodeHierarchy> GetTreeInternalAsync()
-    {
-        var previousTree = await Previous.GetTreeAsync();
-        return await PassTransformer.ApplyTransformationsAsync(previousTree, Transformations);
-    }
+    public AstNodeHierarchy Tree =>
+        tree ??= PassTransformer.ApplyTransformations(Previous.Tree, Transformations);
 }
 
 /// <summary>

--- a/src/NanopassSharp/Pass.cs
+++ b/src/NanopassSharp/Pass.cs
@@ -47,7 +47,7 @@ public sealed record class CompilerPass
 /// <param name="Transformations">A list of transformations.</param>
 public sealed record class PassTransformations
 (
-    IList<ITransformation> Transformations
+    IList<ITransformationInfo> Transformations
 );
 
 /// <summary>

--- a/src/NanopassSharp/Pass.cs
+++ b/src/NanopassSharp/Pass.cs
@@ -69,11 +69,3 @@ public sealed record class Member
     string? Type,
     ISet<object> Attributes
 );
-
-class C
-{
-    static void M()
-    {
-        Member member = new(null!, null, null, null!);
-    }
-}

--- a/src/NanopassSharp/Pass.cs
+++ b/src/NanopassSharp/Pass.cs
@@ -45,7 +45,7 @@ public sealed record class CompilerPass
 /// <param name="Transformations">A list of transformations.</param>
 public sealed record class PassTransformations
 (
-    IList<ITransformationInfo> Transformations
+    IList<ITransformationDescription> Transformations
 );
 
 /// <summary>

--- a/src/NanopassSharp/Pass.cs
+++ b/src/NanopassSharp/Pass.cs
@@ -53,11 +53,12 @@ public sealed record class PassTransformations
 /// <summary>
 /// A tree of nodes representing types which are the input and output of a pass.
 /// </summary>
-/// <param name="Root">The root node.</param>
+/// <param name="Roots">The root nodes.
+/// May be multiple if the language does not support nested types.</param>
 /// <param name="Nodes">The nodes of the tree.</param>
 public sealed record class AstNodeHierarchy
 (
-    AstNode Root,
+    IList<AstNode> Roots,
     IDictionary<string, AstNode> Nodes
 );
 
@@ -67,7 +68,7 @@ public sealed record class AstNodeHierarchy
 /// <param name="Name">The name of the type.</param>
 /// <param name="Documentation">The type's corresponding documentation.</param>
 /// <param name="Parent">The parent type node.
-/// <see langword="null"/> if the node is the root node.</param>
+/// <see langword="null"/> if the node is a root node.</param>
 /// <param name="Children">The children of the node (typically nested types).</param>
 /// <param name="Members">The members of the type.</param>
 /// <param name="Attributes">The language-specific attributes of the type.</param>
@@ -82,7 +83,7 @@ public sealed record class AstNode
 );
 
 /// <summary>
-/// A member of a type.
+/// A member of a <see cref="AstNode"/>.
 /// </summary>
 /// <param name="Name">The name of the member.</param>
 /// <param name="Documentation">The member's corresponding documentation.</param>

--- a/src/NanopassSharp/Pass.cs
+++ b/src/NanopassSharp/Pass.cs
@@ -1,5 +1,6 @@
-﻿using System.Collections.Generic;
-using System.Threading.Tasks;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace NanopassSharp;
 
@@ -48,9 +49,26 @@ public sealed record class PassTransformations
 /// <param name="Nodes">The nodes of the tree.</param>
 public sealed record class AstNodeHierarchy
 (
-    IList<AstNode> Roots,
-    IDictionary<string, AstNode> Nodes
-);
+    IList<AstNode> Roots
+)
+{
+    public bool Equals(AstNodeHierarchy? other)
+    {
+        if (other is null) return false;
+
+        if (!other.Roots.SequenceEqual(Roots)) return false;
+
+        return true;
+    }
+    public override int GetHashCode()
+    {
+        HashCode hashCode = new();
+
+        foreach (var root in Roots) hashCode.Add(root);
+
+        return hashCode.ToHashCode();
+    }
+}
 
 /// <summary>
 /// A node representing a type in a compiler pass.
@@ -70,7 +88,32 @@ public sealed record class AstNode
     IDictionary<string, AstNode> Children,
     IDictionary<string, AstNodeMember> Members,
     ISet<object> Attributes
-);
+)
+{
+    public bool Equals(AstNode? other)
+    {
+        if (other is null) return false;
+
+        if (other.Name != Name) return false;
+        if (other.Documentation != Documentation) return false;
+        if (!other.Children.DictionaryEquals(Children)) return false;
+        if (!other.Members.DictionaryEquals(Members)) return false;
+        if (!other.Attributes.SetEquals(Attributes)) return false;
+        return true;
+    }
+    public override int GetHashCode()
+    {
+        HashCode hashCode = new();
+
+        hashCode.Add(Name);
+        hashCode.Add(Documentation);
+        foreach (var child in Children.Values) hashCode.Add(child);
+        foreach (var member in Members.Values) hashCode.Add(member);
+        foreach (object attribute in Attributes) hashCode.Add(attribute);
+
+        return hashCode.ToHashCode();
+    }
+}
 
 /// <summary>
 /// A member of a <see cref="AstNode"/>.
@@ -87,4 +130,28 @@ public sealed record class AstNodeMember
     string? Documentation,
     string? Type,
     ISet<object> Attributes
-);
+)
+{
+    public bool Equals(AstNodeMember? other)
+    {
+        if (other is null) return false;
+
+        if (other.Name != Name) return false;
+        if (other.Documentation != Documentation) return false;
+        if (other.Type != Type) return false;
+        if (!other.Attributes.SetEquals(Attributes)) return false;
+
+        return true;
+    }
+    public override int GetHashCode()
+    {
+        HashCode hashCode = new();
+
+        hashCode.Add(Name);
+        hashCode.Add(Documentation);
+        hashCode.Add(Type);
+        foreach (object attribute in Attributes) hashCode.Add(attribute);
+
+        return hashCode.ToHashCode();
+    }
+}

--- a/src/NanopassSharp/Pass.cs
+++ b/src/NanopassSharp/Pass.cs
@@ -1,0 +1,79 @@
+﻿using System.Collections.Generic;
+
+namespace NanopassSharp;
+
+/// <summary>
+/// A single compiler pass.
+/// </summary>
+/// <param name="Name">The name of the pass.</param>
+/// <param name="Documentation">The pass' corresponding documentation.</param>
+/// <param name="Transformations">The transformations the pass applies to its nodes.</param>
+/// <param name="Tree">The original node tree of the pass.</param>
+public sealed record class Pass
+(
+    string Name,
+    string? Documentation,
+    Pass Previous,
+    IList<ITransformation> Transformations,
+    // Should this be immutable?
+    // Should the tree be the tree resulting from applying the pass' transformations?
+    // Should it be created immediately by the language-specific parser
+    // or be based on the previous pass?
+    TypeNodeTree Tree
+);
+
+/// <summary>
+/// A tree of nodes representing types which are the input and output of a pass.
+/// </summary>
+/// <param name="Root">The root node.</param>
+/// <param name="Nodes">The nodes of the tree.</param>
+public sealed record class TypeNodeTree
+(
+    TypeNode Root,
+    IDictionary<string, TypeNode> Nodes
+);
+
+/// <summary>
+/// A node representing a type in a compiler pass.
+/// </summary>
+/// <param name="Name">The name of the type.</param>
+/// <param name="Documentation">The type's corresponding documentation.</param>
+/// <param name="Parent">The parent type node.
+/// <see langword="null"/> if the node is the root node.</param>
+/// <param name="Children">The children of the node (typically nested types).</param>
+/// <param name="Members">The members of the type.</param>
+/// <param name="Attributes">The language-specific attributes of the type.</param>
+public sealed record class TypeNode
+(
+    string Name,
+    string? Documentation,
+    TypeNode? Parent,
+    IDictionary<string, TypeNode> Children,
+    IDictionary<string, Member> Members,
+    ISet<object> Attributes
+);
+
+/// <summary>
+/// A member of a type.
+/// </summary>
+/// <param name="Name">The name of the member.</param>
+/// <param name="Documentation">The member's corresponding documentation.</param>
+/// <param name="Type">The type of the member.
+/// May be <see langword="null"/> in dynamically typed languages
+/// or languages without explicitly typed members.</param>
+/// <param name="Attributes">The language-specific attributes of the member.</param>
+public sealed record class Member
+(
+    string Name,
+    string? Documentation,
+    string? Type,
+    ISet<object> Attributes
+);
+
+class C
+{
+    static void M()
+    {
+        Member member = new(null!, null, null, null!);
+    }
+}

--- a/src/NanopassSharp/Pass.cs
+++ b/src/NanopassSharp/Pass.cs
@@ -18,7 +18,6 @@ public sealed record class CompilerPass
     CompilerPass Previous
 )
 {
-
     /// <summary>
     /// The next pass immediately based on this pass.
     /// </summary>
@@ -38,7 +37,6 @@ public sealed record class CompilerPass
         var previousTree = await Previous.GetTreeAsync();
         return await PassTransformer.ApplyTransformationsAsync(previousTree, Transformations);
     }
-
 }
 
 /// <summary>

--- a/src/NanopassSharp/Pass.cs
+++ b/src/NanopassSharp/Pass.cs
@@ -10,30 +10,30 @@ namespace NanopassSharp;
 /// <param name="Documentation">The pass' corresponding documentation.</param>
 /// <param name="Transformations">The transformations the pass applies to its nodes.</param>
 /// <param name="Previous">The previous pass which this pass is based on.</param>
-public sealed record class Pass
+public sealed record class CompilerPass
 (
     string Name,
     string? Documentation,
     PassTransformations Transformations,
-    Pass Previous
+    CompilerPass Previous
 )
 {
 
     /// <summary>
     /// The next pass immediately based on this pass.
     /// </summary>
-    public Pass? Next { get; set; }
+    public CompilerPass? Next { get; set; }
 
-    private Task<TypeNodeTree>? treeTask;
+    private Task<AstNodeHierarchy>? treeTask;
     /// <summary>
     /// Gets the transformed tree of this pass.
     /// </summary>
-    public Task<TypeNodeTree> GetTreeAsync()
+    public Task<AstNodeHierarchy> GetTreeAsync()
     {
         treeTask ??= GetTreeInternalAsync();
         return treeTask;
     }
-    private async Task<TypeNodeTree> GetTreeInternalAsync()
+    private async Task<AstNodeHierarchy> GetTreeInternalAsync()
     {
         var previousTree = await Previous.GetTreeAsync();
         return await PassTransformer.ApplyTransformationsAsync(previousTree, Transformations);
@@ -42,7 +42,7 @@ public sealed record class Pass
 }
 
 /// <summary>
-/// The transformations applied by a <see cref="Pass"/>.
+/// The transformations applied by a <see cref="CompilerPass"/>.
 /// </summary>
 /// <param name="Transformations">A list of transformations.</param>
 public sealed record class PassTransformations
@@ -55,10 +55,10 @@ public sealed record class PassTransformations
 /// </summary>
 /// <param name="Root">The root node.</param>
 /// <param name="Nodes">The nodes of the tree.</param>
-public sealed record class TypeNodeTree
+public sealed record class AstNodeHierarchy
 (
-    TypeNode Root,
-    IDictionary<string, TypeNode> Nodes
+    AstNode Root,
+    IDictionary<string, AstNode> Nodes
 );
 
 /// <summary>
@@ -71,13 +71,13 @@ public sealed record class TypeNodeTree
 /// <param name="Children">The children of the node (typically nested types).</param>
 /// <param name="Members">The members of the type.</param>
 /// <param name="Attributes">The language-specific attributes of the type.</param>
-public sealed record class TypeNode
+public sealed record class AstNode
 (
     string Name,
     string? Documentation,
-    TypeNode? Parent,
-    IDictionary<string, TypeNode> Children,
-    IDictionary<string, Member> Members,
+    AstNode? Parent,
+    IDictionary<string, AstNode> Children,
+    IDictionary<string, AstNodeMember> Members,
     ISet<object> Attributes
 );
 
@@ -90,7 +90,7 @@ public sealed record class TypeNode
 /// May be <see langword="null"/> in dynamically typed languages
 /// or languages without explicitly typed members.</param>
 /// <param name="Attributes">The language-specific attributes of the member.</param>
-public sealed record class Member
+public sealed record class AstNodeMember
 (
     string Name,
     string? Documentation,

--- a/src/NanopassSharp/PassExtensions.cs
+++ b/src/NanopassSharp/PassExtensions.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace NanopassSharp;
+
+public static class PassExtensions
+{
+    public static IEnumerable<AstNode> GetNodes(this AstNodeHierarchy tree) =>
+        tree.Roots.SelectMany(r => r.GetDecendantNodesAndSelf());
+    public static IEnumerable<AstNode> GetDecendantNodes(this AstNode node) =>
+        node.Children.Values.SelectMany(n => n.GetDecendantNodes());
+    public static IEnumerable<AstNode> GetDecendantNodesAndSelf(this AstNode node) =>
+        node.GetDecendantNodes().Prepend(node);
+    public static AstNode GetRoot(this AstNode node) =>
+        node.Parent?.GetRoot() ?? node;
+
+    public static AstNodeHierarchy ReplaceNode(this AstNodeHierarchy tree, AstNode oldNode, AstNode newNode)
+    {
+        var root = oldNode.GetRoot();
+        if (!tree.Roots.Contains(root)) throw new ArgumentException("Node does not exist in the tree", nameof(oldNode));
+
+        var parent = oldNode.Parent;
+        if (parent is null) return tree with
+        {
+            Roots = tree.Roots.ToImmutableArray().Replace(oldNode, newNode)
+        };
+
+        string name = oldNode.Name;
+        var node = newNode with
+        {
+            Name = name
+        };
+        var newParent = parent with
+        {
+            Children = parent.Children.ToImmutableDictionary().SetItem(name, node)
+        };
+        return tree.ReplaceNode(parent, newParent);
+    }
+    public static AstNodeHierarchy RemoveNode(this AstNodeHierarchy tree, AstNode node)
+    {
+        var root = node.GetRoot();
+        if (!tree.Roots.Contains(root)) throw new ArgumentException("Node does not exist in the tree", nameof(node));
+
+        var parent = node.Parent;
+        if (parent is null) return tree with
+        {
+            Roots = tree.Roots.ToImmutableArray().Remove(node)
+        };
+
+        string name = node.Name;
+        var newParent = parent with
+        {
+            Children = parent.Children.ToImmutableDictionary().Remove(name)
+        };
+        return tree.ReplaceNode(parent, newParent);
+    }
+    
+    public static AstNode ReplaceMember(this AstNode node, AstNodeMember oldMember, AstNodeMember newMember)
+    {
+        string name = oldMember.Name;
+        if (!node.Members.ContainsKey(name)) throw new ArgumentException("Member does not exist in the node", nameof(oldMember));
+
+        var member = newMember with
+        {
+            Name = name
+        };
+        return node with
+        {
+            Members = node.Members.ToImmutableDictionary().SetItem(name, member)
+        };
+    }
+    public static AstNode RemoveMember(this AstNode node, AstNodeMember member)
+    {
+        string name = member.Name;
+        if (!node.Members.ContainsKey(name)) throw new ArgumentException("Member does not exist in the node", nameof(member));
+
+        return node with
+        {
+            Members = node.Members.ToImmutableDictionary().Remove(name)
+        };
+    }
+}

--- a/src/NanopassSharp/PassGenerator.cs
+++ b/src/NanopassSharp/PassGenerator.cs
@@ -15,7 +15,6 @@ namespace NanopassSharp;
 
 public sealed class PassGenerator
 {
-
     private const string nanopassSharpNamespace = "NanopassSharp";
     private const string passAttributeName = "PassAttribute";
     private const string passAttributeFullName = $"{nanopassSharpNamespace}.{passAttributeName}";
@@ -284,5 +283,4 @@ public sealed class PassAttribute : Attribute {
             .WithParameterList(parameterList)
             .WithMembers(new(members));
     }
-
 }

--- a/src/NanopassSharp/PassSourceGenerator.cs
+++ b/src/NanopassSharp/PassSourceGenerator.cs
@@ -15,7 +15,6 @@ namespace NanopassSharp;
 
 internal static class PassSourceGenerator
 {
-
     public readonly record struct ModifiedTypeResult(string Source, NamespacedTypeName TypeName);
     public static Result<ModifiedTypeResult> GetModifiedTypeSource(RecordDeclarationSyntax baseSyntax, INamedTypeSymbol baseType, PassModel pass, ModificationPassModel mod)
     {
@@ -248,5 +247,4 @@ internal static class PassSourceGenerator
         return parentMods
             .Concat(mods);
     }
-
 }

--- a/src/NanopassSharp/PassTransformer.cs
+++ b/src/NanopassSharp/PassTransformer.cs
@@ -12,7 +12,7 @@ public static class PassTransformer
     /// <param name="transformations">The transformations to apply.</param>
     /// <returns></returns>
     /// <exception cref="NotImplementedException"></exception>
-    public static Task<AstNodeHierarchy> ApplyTransformationsAsync(AstNodeHierarchy tree, PassTransformations transformations)
+    public static AstNodeHierarchy ApplyTransformations(AstNodeHierarchy tree, PassTransformations transformations)
     {
         throw new NotImplementedException();
     }

--- a/src/NanopassSharp/PassTransformer.cs
+++ b/src/NanopassSharp/PassTransformer.cs
@@ -5,7 +5,6 @@ namespace NanopassSharp;
 
 public static class PassTransformer
 {
-
     /// <summary>
     /// Applies transformations to a <see cref="AstNodeHierarchy"/>.
     /// </summary>
@@ -17,5 +16,4 @@ public static class PassTransformer
     {
         throw new NotImplementedException();
     }
-
 }

--- a/src/NanopassSharp/PassTransformer.cs
+++ b/src/NanopassSharp/PassTransformer.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace NanopassSharp;
+
+public static class PassTransformer
+{
+
+    public static Task<TypeNodeTree> ApplyTransformationsAsync(TypeNodeTree previousTree, PassTransformations transformations)
+    {
+        throw new NotImplementedException();
+    }
+
+}

--- a/src/NanopassSharp/PassTransformer.cs
+++ b/src/NanopassSharp/PassTransformer.cs
@@ -6,7 +6,7 @@ namespace NanopassSharp;
 public static class PassTransformer
 {
 
-    public static Task<TypeNodeTree> ApplyTransformationsAsync(TypeNodeTree previousTree, PassTransformations transformations)
+    public static Task<AstNodeHierarchy> ApplyTransformationsAsync(AstNodeHierarchy previousTree, PassTransformations transformations)
     {
         throw new NotImplementedException();
     }

--- a/src/NanopassSharp/PassTransformer.cs
+++ b/src/NanopassSharp/PassTransformer.cs
@@ -6,7 +6,14 @@ namespace NanopassSharp;
 public static class PassTransformer
 {
 
-    public static Task<AstNodeHierarchy> ApplyTransformationsAsync(AstNodeHierarchy previousTree, PassTransformations transformations)
+    /// <summary>
+    /// Applies transformations to a <see cref="AstNodeHierarchy"/>.
+    /// </summary>
+    /// <param name="tree">The tree to transform.</param>
+    /// <param name="transformations">The transformations to apply.</param>
+    /// <returns></returns>
+    /// <exception cref="NotImplementedException"></exception>
+    public static Task<AstNodeHierarchy> ApplyTransformationsAsync(AstNodeHierarchy tree, PassTransformations transformations)
     {
         throw new NotImplementedException();
     }

--- a/src/NanopassSharp/RoslynExtensions.cs
+++ b/src/NanopassSharp/RoslynExtensions.cs
@@ -9,7 +9,6 @@ namespace NanopassSharp;
 
 public static class RoslynExtensions
 {
-
     public static IEnumerable<INamedTypeSymbol> GetAllTypes(this INamespaceSymbol source) =>
         source
             .GetTypeMembers()
@@ -38,5 +37,4 @@ public static class RoslynExtensions
 
     public static string GetTextWithoutTrivia(this SyntaxNode node) =>
         node.WithoutTrivia().GetText().ToString();
-
 }


### PR DESCRIPTION
Update the model used for representing type node trees and passes in accordance with the language overhaul proposal (see #2). The exact implementation is still being actively discussed and this PR currently serves as more of a test to see what would work.