### PR TITLE
Prototype language API

### DIFF
--- a/src/NanopassSharp/ExecutionContext.cs
+++ b/src/NanopassSharp/ExecutionContext.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+using System.IO;
+
+namespace NanopassSharp;
+
+/// <summary>
+/// A context for an execution.
+/// </summary>
+/// <param name="Directory">The root directory of the current execution.</param>
+/// <param name="Args">The argument passed to the execution.</param>
+public readonly record struct ExecutionContext(
+    DirectoryInfo Directory,
+    IReadOnlyDictionary<string, string> Args
+);

--- a/src/NanopassSharp/ILanguage.cs
+++ b/src/NanopassSharp/ILanguage.cs
@@ -1,0 +1,66 @@
+﻿using System.Threading.Tasks;
+
+namespace NanopassSharp;
+
+/// <summary>
+/// Defines a language.
+/// </summary>
+public interface ILanguage : ISourceHierarchyLocator
+{
+    /// <summary>
+    /// The name of the language.
+    /// </summary>
+    string Name { get; }
+
+    /// <summary>
+    /// Emits an <see cref="AstNodeHierarchy"/> to the current context.
+    /// </summary>
+    /// <param name="hierarchy">The hierarchy to emit.</param>
+    /// <param name="context">The context of the current execution.</param>
+    Task EmitAsync(AstNodeHierarchy hierarchy, ExecutionContext context);
+}
+
+/// <summary>
+/// A locator for the source hierarchy of a given context.
+/// </summary>
+public interface ISourceHierarchyLocator
+{
+    /// <summary>
+    /// Locates the source hierarchy based on the name of the hierarchy.
+    /// </summary>
+    /// <param name="name">The name of the hierarchy to locate.</param>
+    /// <param name="context">The current execution context.</param>
+    /// <returns>The source hierarchy,
+    /// or <see langword="null"/> if the hierarchy could not be found.</returns>
+    Task<AstNodeHierarchy?> LocateSourceHierarchyAsync(string name, ExecutionContext context);
+}
+
+/// <summary>
+/// A provider for a single language.
+/// </summary>
+public interface ILanguageProvider
+{
+    /// <summary>
+    /// The pattern which determines whether the language should be used.
+    /// </summary>
+    ILanguagePattern Pattern { get; }
+
+    /// <summary>
+    /// Creates a language.
+    /// </summary>
+    /// <param name="context">The current execution context.</param>
+    /// <returns>A new <see cref="ILanguage"/>.</returns>
+    Task<ILanguage> CreateLanguageAsync(ExecutionContext context);
+}
+
+/// <summary>
+/// A pattern which determines whether a language should be used.
+/// </summary>
+public interface ILanguagePattern
+{
+    /// <summary>
+    /// Returns whether to use the language based on the current context.
+    /// </summary>
+    /// <param name="context">The current execution context.</param>
+    Task<bool> IsMatchAsync(ExecutionContext context);
+}

--- a/src/NanopassSharp/IPassInputFormat.cs
+++ b/src/NanopassSharp/IPassInputFormat.cs
@@ -1,0 +1,16 @@
+﻿using System.Threading.Tasks;
+
+namespace NanopassSharp;
+
+/// <summary>
+/// An input format for a pass sequence.
+/// </summary>
+public interface IPassInputFormat
+{
+    /// <summary>
+    /// Generates a <see cref="PassSequence"/> from the current input.
+    /// </summary>
+    /// <param name="context">The context for the current execution.</param>
+    /// <returns>A <see cref="PassSequence"/> retrieved from the current context.</returns>
+    Task<PassSequence> GeneratePassSequenceAsync(ExecutionContext context);
+}


### PR DESCRIPTION
A rough draft for the API for input/output languages.

The core interfaces are `ILanguage`, `ILanguageProvider` and `IPassInputLanguage`, as well as the `ExecutionContext` struct.
- `ILanguage` is the most important as it handles loading an AST node hierarchy from the provided context, for instance loading a C# type from a provided name and the current directory.
- `ILanguageProvider` handles logic for recognizing a language using the `ILanguagePattern` interface (for instance locating a `.csproj` file in the current directory), and creating a language based on the current context (for instance loading a C# project using Roslyn and returning a new `ILanguage` representing the C# language).
- `IPassInputLanguage` specifies a language which parses the input passes, for instance JSON or YAML.
- `ExecutionContext` is the context for an execution of the generator. It (currently) contains the current directory for IO operations, as well as a read-only dictionary of additional arguments passed to the program. This would allow for language-specific arguments, which could be somewhat useful.